### PR TITLE
updates to support xyz.js client-side pixel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,108 +1,43 @@
 'use strict';
 
-// Spec: https://github.com/segmentio/analytics.js-private/issues/79
-
-/**
- * Module dependencies.
- */
-
-var Identify = require('segmentio-facade').Identify;
-var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');
+// var Batch = require('batch');
 
 /**
- * Expose `Rockerbox`.
+ * Expose `rockerbox`
+ *
+ * https://github.com/segmentio/analytics.js-private/issues/79
  */
 
 var Rockerbox = module.exports = integration('Rockerbox')
-  .option('source', '')
-  .option('allAnSeg', '')
-  .option('customerAnSeg', '')
-  .option('conversionId', '')
-  .option('segmentId', '')
-  .mapping('events')
-  .tag('page', '<script src="https://getrockerbox.com/pixel?source={{ source }}&type=imp&an_seg={{ allAnSeg }}">')
-  .tag('user', '<script src="https://getrockerbox.com/pixel?source={{ source }}&type=imp&an_seg={{ customerAnSeg }}">')
-  .tag('appnexus', '<script src="https://secure.adnxs.com/px?id={{ conversionId }}&seg={{ segmentId }}&t=1&order_id={{ id }}">')
-  .tag('track', '<script src="https://getrockerbox.com/pixel?source={{ source }}&type=conv&id={{ conversionId }}&an_seg={{ segmentId }}&order_type={{ id }}">');
+  .global('RB')
+  .option('pixel_code','')
+  .tag('<script src="//getrockerbox.com/assets/xyz.js">');
 
-/**
- * Initialize.
- *
- * @api public
- */
 
 Rockerbox.prototype.initialize = function() {
-  this.ready();
+  window.RB = {};
+  window.RB.disablePushState = true;
+  window.RB.queue = [];
+  window.RB.track = window.RB.track || function() {
+    window.RB.queue.push(Array.prototype.slice.call(arguments));
+  };
+  window.RB.source = this.options.pixel_code;
+
+  this.load(this.ready);
 };
 
-/**
- * Page.
- *
- * @api public
- */
+Rockerbox.prototype.loaded = function() {
+  return !!window.RB && !!window.RB.track;
+};
 
 Rockerbox.prototype.page = function() {
-  var user = this.analytics.user();
-  // order of query parameters is important
-  this.load('page');
-  if (user.id()) this.load('user');
+  window.RB.track('view');
 };
-
-/**
- * Track.
- *
- * @param {Track} track
- */
 
 Rockerbox.prototype.track = function(track) {
-  var user = this.analytics.user();
-  var events = this.events(track.event());
-  var self = this;
-
-  each(events, function(event) {
-    var conversionId = event.conversionId;
-    var segmentId = event.segmentId;
-    var property = event.property || 'email';
-    var id;
-
-    switch (property) {
-    case 'email':
-      id = user && email(user);
-      break;
-    case 'orderId':
-      id = track.orderId();
-      break;
-    case 'userId':
-      id = user && user.id();
-      break;
-    case 'revenue':
-      id = track.revenue();
-      break;
-    default:
-        // No default case
-    }
-
-    var params = {
-      conversionId: conversionId,
-      segmentId: segmentId,
-      id: id
-    };
-
-    // load 2 pixels, parameter order is important.
-    self.load('appnexus', params);
-    self.load('track', params);
-  });
+  var event = track.event();
+  var payload = track.properties();
+  window.RB.track(event, payload);
 };
 
-/**
- * Get email from user.
- *
- * @param {Object} user
- * @return {String}
- */
-
-function email(user) {
-  var identify = new Identify({ userId: user.id(), traits: user.traits() });
-  return identify.email();
-}


### PR DESCRIPTION
Porting pull request over from https://github.com/patrickotoole/integration-rockerbox/tree/client_side to this repo

Currently, clients have not been able to use the new features of our pixel. This prevents them from receiving accurate information within the Rockerbox platform. The new implementation will allow them to track all types of events that may occur on their site, giving them greater flexibility. 

The former implementation has been deprecated for some time and we are making a renewed push to transition any client to the new implementation. 

Current customers integrated with segment should not be impacted by this change.